### PR TITLE
issue #15: add try/catch with printStackTrace on AsyncTask method call

### DIFF
--- a/conektasdk/src/main/java/com/conekta/conektasdk/Connection.java
+++ b/conektasdk/src/main/java/com/conekta/conektasdk/Connection.java
@@ -39,7 +39,11 @@ public class Connection {
     public void request(List<NameValuePair> nameValuePair, String endPoint) {
         this.nameValuePair = nameValuePair;
         this.endPoint = endPoint;
-        new Task().execute();
+        try {
+            new Task().execute();
+        } catch (RuntimeException ex) {
+            ex.printStackTrace();
+        }
     }
 
     private class Task extends AsyncTask<Void, Void, String> {


### PR DESCRIPTION
This just prints the error so the developer has knowledge about the problem, but it does not let the developer handle the error to display any message or something.